### PR TITLE
Eliminate dependence on system string.h.

### DIFF
--- a/src/main/commsCore.c
+++ b/src/main/commsCore.c
@@ -51,7 +51,7 @@
 #include "inc/decoderInterface.h"
 #include "inc/commsCore.h"
 #include "inc/init.h"
-#include <string.h> /// @todo TODO this is pulling in the system string.h not the m68hc1x version, and functions other than memcpy do not work because they are not in crt1.o or other included-by-default libs
+#include <stddef.h>
 #include "decoders/inc/BenchTest.h"
 
 
@@ -77,7 +77,7 @@ unsigned short populateBasicDatalog(){
 			confSize -= localSize;
 			break;
 		}
-		memcpy(TXBufferCurrentPositionHandler, TablesB.SmallTablesB.loggingSettings.logChunks[chunks].address, localSize);
+		__builtin_memcpy(TXBufferCurrentPositionHandler, TablesB.SmallTablesB.loggingSettings.logChunks[chunks].address, localSize);
 		TXBufferCurrentPositionHandler += localSize;
 	}
 	// After copying data, otherwise tempClock is NEVER zero and reset detection does NOT work
@@ -318,7 +318,7 @@ void decodePacketAndRespond(){
 			*TXHeaderFlags |= HEADER_HAS_LENGTH;
 			TXBufferCurrentPositionHandler += 2;
 			/* Load the body into place */
-			memcpy((void*)TXBufferCurrentPositionHandler, (void*)&interfaceVersion, sizeof(interfaceVersion));
+			__builtin_memcpy((void*)TXBufferCurrentPositionHandler, (void*)&interfaceVersion, sizeof(interfaceVersion));
 			TXBufferCurrentPositionHandler += sizeof(interfaceVersion);
 			break;
 		}
@@ -333,7 +333,7 @@ void decodePacketAndRespond(){
 			*TXHeaderFlags |= HEADER_HAS_LENGTH;
 			TXBufferCurrentPositionHandler += 2;
 			/* Load the body into place */
-			memcpy((void*)TXBufferCurrentPositionHandler, (void*)&firmwareVersion, sizeof(firmwareVersion));
+			__builtin_memcpy((void*)TXBufferCurrentPositionHandler, (void*)&firmwareVersion, sizeof(firmwareVersion));
 			TXBufferCurrentPositionHandler += sizeof(firmwareVersion);
 			break;
 		}
@@ -355,7 +355,7 @@ void decodePacketAndRespond(){
 			*TXHeaderFlags |= HEADER_HAS_LENGTH;
 			TXBufferCurrentPositionHandler += 2;
 			/* Load the body into place */
-			memcpy((void*)TXBufferCurrentPositionHandler, (void*)&RXBuffer, RXPacketLengthReceived);
+			__builtin_memcpy((void*)TXBufferCurrentPositionHandler, (void*)&RXBuffer, RXPacketLengthReceived);
 			/* Note, there is no overflow check here because the TX buffer is slightly       */
 			/* bigger than the RX buffer and there is overflow checking for receives anyway. */
 			TXBufferCurrentPositionHandler += RXPacketLengthReceived;
@@ -531,10 +531,10 @@ void decodePacketAndRespond(){
 				// For sub regions, construct an image for verification
 				if(size != details.size){
 					// Copy data from destination location to buffer
-					memcpy(leftOverBuffer, details.RAMAddress, details.size);
+					__builtin_memcpy(leftOverBuffer, details.RAMAddress, details.size);
 
 					// Copy data from rx buffer to buffer over writing old data
-					memcpy(leftOverBuffer + offset, RXBufferCurrentPosition, size);
+					__builtin_memcpy(leftOverBuffer + offset, RXBufferCurrentPosition, size);
 
 					bufferToCheck = leftOverBuffer;
 				}else{
@@ -556,7 +556,7 @@ void decodePacketAndRespond(){
 			}
 
 			// Copy from the RX buffer to the block of RAM
-			memcpy((unsigned char*)(details.RAMAddress + offset), RXBufferCurrentPosition, size);
+			__builtin_memcpy((unsigned char*)(details.RAMAddress + offset), RXBufferCurrentPosition, size);
 
 			// Check that the write was successful
 			unsigned char index = compare(RXBufferCurrentPosition, (unsigned char*)(details.RAMAddress + offset), size);
@@ -629,13 +629,13 @@ void decodePacketAndRespond(){
 					PPAGE = details.FlashPage;
 
 					// Copy data from destination location to buffer
-					memcpy(leftOverBuffer, details.FlashAddress, details.size);
+					__builtin_memcpy(leftOverBuffer, details.FlashAddress, details.size);
 
 					/* Restore the original flash page */
 					PPAGE = oldFlashPage;
 
 					// Copy data from rx buffer to buffer over writing old data
-					memcpy(leftOverBuffer + offset, RXBufferCurrentPosition, size);
+					__builtin_memcpy(leftOverBuffer + offset, RXBufferCurrentPosition, size);
 
 					bufferToCheck = leftOverBuffer;
 				}else{
@@ -677,7 +677,7 @@ void decodePacketAndRespond(){
 				RPAGE = details.RAMPage;
 
 				/* Copy from the RX buffer to the block of RAM */
-				memcpy((unsigned char*)(details.RAMAddress + offset), RXBufferCurrentPosition, size);
+				__builtin_memcpy((unsigned char*)(details.RAMAddress + offset), RXBufferCurrentPosition, size);
 
 				/* Check that the write was successful */
 				unsigned char index = compare(RXBufferCurrentPosition, (unsigned char*)(details.RAMAddress + offset), size);
@@ -747,7 +747,7 @@ void decodePacketAndRespond(){
 			RPAGE = details.RAMPage;
 
 			/* Copy the block of RAM to the TX buffer */
-			memcpy(TXBufferCurrentPositionHandler, (unsigned char*)(details.RAMAddress + offset), size);
+			__builtin_memcpy(TXBufferCurrentPositionHandler, (unsigned char*)(details.RAMAddress + offset), size);
 			TXBufferCurrentPositionHandler += size;
 
 			/* Restore the original RAM and flash pages */
@@ -810,7 +810,7 @@ void decodePacketAndRespond(){
 			PPAGE = details.FlashPage;
 
 			/* Copy the block of flash to the TX buffer */
-			memcpy(TXBufferCurrentPositionHandler, (unsigned char*)(details.FlashAddress + offset), size);
+			__builtin_memcpy(TXBufferCurrentPositionHandler, (unsigned char*)(details.FlashAddress + offset), size);
 			TXBufferCurrentPositionHandler += size;
 
 			/* Restore the original RAM and flash pages */
@@ -962,7 +962,7 @@ void decodePacketAndRespond(){
 			TXBufferCurrentPositionHandler++;
 
 			/* Load the body into place */
-			memcpy((void*)TXBufferCurrentPositionHandler, address, length);
+			__builtin_memcpy((void*)TXBufferCurrentPositionHandler, address, length);
 			TXBufferCurrentPositionHandler += length;
 
 			break;
@@ -1239,7 +1239,7 @@ void decodePacketAndRespond(){
 				RXBufferCurrentPosition += 6;
 				unsigned short* testPulseWidths = (unsigned short*)RXBufferCurrentPosition;
 				RXBufferCurrentPosition += 12;
-				memcpy((void*)TXBufferCurrentPositionHandler, (void*)testEventNumbers, 18);
+				__builtin_memcpy((void*)TXBufferCurrentPositionHandler, (void*)testEventNumbers, 18);
 				TXBufferCurrentPositionHandler += 18;
 
 				// Reset the clock for reading timeout

--- a/src/main/flashWrite.c
+++ b/src/main/flashWrite.c
@@ -43,7 +43,7 @@
 #include "inc/flashBurn.h"
 #include "inc/commsISRs.h"
 #include "inc/commsCore.h"
-#include <string.h>
+#include <stddef.h>
 
 
 /** @brief Erases a sector of flash memory
@@ -139,21 +139,21 @@ unsigned short writeBlock(blockDetails* details, void* buffer){
 
 		/* If the chunk doesn't start at the beginning of the sector, copy the first area from flash */
 		if(offset != 0){
-			memcpy(buffer, FlashAddress, offset);
+			__builtin_memcpy(buffer, FlashAddress, offset);
 			buffer += offset;
 		}
 
 		/* Copy the middle section up regardless */
 		unsigned char oldRAMPage = RPAGE;
 		RPAGE = details->RAMPage;
-		memcpy(buffer, details->RAMAddress, details->size);
+		__builtin_memcpy(buffer, details->RAMAddress, details->size);
 		buffer += details->size;
 		RPAGE = oldRAMPage;
 
 		/* If the chunk doesn't end at the end of the sector, copy the last are from flash */
 		if((offset + details->size) < 1024){
 			void* chunkFlashEndAddress = details->FlashAddress + details->size;
-			memcpy(buffer, chunkFlashEndAddress, (1024 - (offset + details->size)));
+			__builtin_memcpy(buffer, chunkFlashEndAddress, (1024 - (offset + details->size)));
 		}
 
 		/* Restore the PPAGE value back */

--- a/src/main/init.c
+++ b/src/main/init.c
@@ -49,7 +49,8 @@
 #include "inc/init.h"
 #include "inc/decoderInterface.h"
 #include "inc/xgateVectors.h"
-#include <string.h>
+
+#include <stddef.h>
 
 
 /** @brief The main top level init
@@ -258,15 +259,15 @@ void initFuelAddresses(){
 void initPagedRAMFuel(void){
 	/* Copy the tables from flash to RAM */
 	RPAGE = RPAGE_FUEL_ONE;
-	memcpy((void*)&TablesA, VETableMainFlashLocation,       sizeof(mainTable));
-	memcpy((void*)&TablesB, VETableSecondaryFlashLocation,  sizeof(mainTable));
-	memcpy((void*)&TablesC, AirflowTableFlashLocation,      sizeof(mainTable));
-	memcpy((void*)&TablesD, LambdaTableFlashLocation,       sizeof(mainTable));
+	__builtin_memcpy((void*)&TablesA, VETableMainFlashLocation,       sizeof(mainTable));
+	__builtin_memcpy((void*)&TablesB, VETableSecondaryFlashLocation,  sizeof(mainTable));
+	__builtin_memcpy((void*)&TablesC, AirflowTableFlashLocation,      sizeof(mainTable));
+	__builtin_memcpy((void*)&TablesD, LambdaTableFlashLocation,       sizeof(mainTable));
 	RPAGE = RPAGE_FUEL_TWO;
-	memcpy((void*)&TablesA, VETableMainFlash2Location,      sizeof(mainTable));
-	memcpy((void*)&TablesB, VETableSecondaryFlash2Location, sizeof(mainTable));
-	memcpy((void*)&TablesC, AirflowTableFlash2Location,     sizeof(mainTable));
-	memcpy((void*)&TablesD, LambdaTableFlash2Location,      sizeof(mainTable));
+	__builtin_memcpy((void*)&TablesA, VETableMainFlash2Location,      sizeof(mainTable));
+	__builtin_memcpy((void*)&TablesB, VETableSecondaryFlash2Location, sizeof(mainTable));
+	__builtin_memcpy((void*)&TablesC, AirflowTableFlash2Location,     sizeof(mainTable));
+	__builtin_memcpy((void*)&TablesD, LambdaTableFlash2Location,      sizeof(mainTable));
 }
 
 
@@ -294,15 +295,15 @@ void initTimingAddresses(){
 void initPagedRAMTime(){
 	/* Copy the tables from flash to RAM */
 	RPAGE = RPAGE_TIME_ONE;
-	memcpy((void*)&TablesA, IgnitionAdvanceTableMainFlashLocation,        sizeof(mainTable));
-	memcpy((void*)&TablesB, IgnitionAdvanceTableSecondaryFlashLocation,   sizeof(mainTable));
-	memcpy((void*)&TablesC, InjectionAdvanceTableMainFlashLocation,       sizeof(mainTable));
-	memcpy((void*)&TablesD, InjectionAdvanceTableSecondaryFlashLocation,  sizeof(mainTable));
+	__builtin_memcpy((void*)&TablesA, IgnitionAdvanceTableMainFlashLocation,        sizeof(mainTable));
+	__builtin_memcpy((void*)&TablesB, IgnitionAdvanceTableSecondaryFlashLocation,   sizeof(mainTable));
+	__builtin_memcpy((void*)&TablesC, InjectionAdvanceTableMainFlashLocation,       sizeof(mainTable));
+	__builtin_memcpy((void*)&TablesD, InjectionAdvanceTableSecondaryFlashLocation,  sizeof(mainTable));
 	RPAGE = RPAGE_TIME_TWO;
-	memcpy((void*)&TablesA, IgnitionAdvanceTableMainFlash2Location,       sizeof(mainTable));
-	memcpy((void*)&TablesB, IgnitionAdvanceTableSecondaryFlash2Location,  sizeof(mainTable));
-	memcpy((void*)&TablesC, InjectionAdvanceTableMainFlash2Location,      sizeof(mainTable));
-	memcpy((void*)&TablesD, InjectionAdvanceTableSecondaryFlash2Location, sizeof(mainTable));
+	__builtin_memcpy((void*)&TablesA, IgnitionAdvanceTableMainFlash2Location,       sizeof(mainTable));
+	__builtin_memcpy((void*)&TablesB, IgnitionAdvanceTableSecondaryFlash2Location,  sizeof(mainTable));
+	__builtin_memcpy((void*)&TablesC, InjectionAdvanceTableMainFlash2Location,      sizeof(mainTable));
+	__builtin_memcpy((void*)&TablesD, InjectionAdvanceTableSecondaryFlash2Location, sizeof(mainTable));
 }
 
 
@@ -370,23 +371,23 @@ void initTunableAddresses(){
 void initPagedRAMTune(){
 	/* Copy the tables from flash to RAM */
 	RPAGE = RPAGE_TUNE_ONE;
-	memcpy((void*)&TablesA, SmallTablesAFlashLocation, sizeof(mainTable));
-	memcpy((void*)&TablesB, SmallTablesBFlashLocation, sizeof(mainTable));
-	memcpy((void*)&TablesC, SmallTablesCFlashLocation, sizeof(mainTable));
-	memcpy((void*)&TablesD, SmallTablesDFlashLocation, sizeof(mainTable));
+	__builtin_memcpy((void*)&TablesA, SmallTablesAFlashLocation, sizeof(mainTable));
+	__builtin_memcpy((void*)&TablesB, SmallTablesBFlashLocation, sizeof(mainTable));
+	__builtin_memcpy((void*)&TablesC, SmallTablesCFlashLocation, sizeof(mainTable));
+	__builtin_memcpy((void*)&TablesD, SmallTablesDFlashLocation, sizeof(mainTable));
 	RPAGE = RPAGE_TUNE_TWO;
 	// &&&&&&&&&&&&&&&&&&&&&&&&&&&&&& WARNING &&&&&&&&&&&&&&&&&&&&&&&&&&&&&& //
 	//    You will get garbage if you use table switching at this time!!!    //
 	//         XGATE code being run from this region temporarily!!!          //
 	//   Writing to these tables WILL corrupt XGATE code/kill your engine!   //
 	// &&&&&&&&&&&&&&&&&&&&&&&&&&&&&& WARNING &&&&&&&&&&&&&&&&&&&&&&&&&&&&&& //
-	//memcpy(xgateSchedRAMAddress, xgateSchedFlashAddress, (xgateSchedEnd - xgateSched));
-	//memcpy(xgateInjectorsOnRAMAddress, xgateInjectorsOnFlashAddress, (xgateInjectorsOnEnd - xgateInjectorsOn));
-	//memcpy(xgateInjectorsOffRAMAddress, xgateInjectorsOffFlashAddress, (xgateInjectorsOffEnd - xgateInjectorsOff));
-//	memcpy((void*)&TablesA,	SmallTablesAFlash2Location, sizeof(mainTable));
-//	memcpy((void*)&TablesB,	SmallTablesBFlash2Location, sizeof(mainTable));
-//	memcpy((void*)&TablesC,	SmallTablesCFlash2Location, sizeof(mainTable));
-//	memcpy((void*)&TablesD,	SmallTablesDFlash2Location, sizeof(mainTable));
+	//__builtin_memcpy(xgateSchedRAMAddress, xgateSchedFlashAddress, (xgateSchedEnd - xgateSched));
+	//__builtin_memcpy(xgateInjectorsOnRAMAddress, xgateInjectorsOnFlashAddress, (xgateInjectorsOnEnd - xgateInjectorsOn));
+	//__builtin_memcpy(xgateInjectorsOffRAMAddress, xgateInjectorsOffFlashAddress, (xgateInjectorsOffEnd - xgateInjectorsOff));
+//	__builtin_memcpy((void*)&TablesA,	SmallTablesAFlash2Location, sizeof(mainTable));
+//	__builtin_memcpy((void*)&TablesB,	SmallTablesBFlash2Location, sizeof(mainTable));
+//	__builtin_memcpy((void*)&TablesC,	SmallTablesCFlash2Location, sizeof(mainTable));
+//	__builtin_memcpy((void*)&TablesD,	SmallTablesDFlash2Location, sizeof(mainTable));
 }
 
 

--- a/src/main/utils.c
+++ b/src/main/utils.c
@@ -38,7 +38,7 @@
 #include "inc/freeEMS.h"
 #include "inc/commsISRs.h"
 #include "inc/utils.h"
-#include <string.h>
+#include <stddef.h>
 
 
 /** @brief Add two unsigned shorts safely
@@ -202,9 +202,9 @@ void sampleLoopADC(ADCBuffer *Arrays){
 }
 
 
-/* @brief Read ADCs with memcpy()
+/* @brief Read ADCs with __builtin_memcpy()
  *
- * Read ADCs into the correct bank using two fixed calls to memcpy()
+ * Read ADCs into the correct bank using two fixed calls to __builtin_memcpy()
  *
  * @param Arrays a pointer to an ADCBuffer struct to store ADC values in.
  *
@@ -212,8 +212,8 @@ void sampleLoopADC(ADCBuffer *Arrays){
  * @bug this will corrupt your comms if you use it... don't use it
  *
 void sampleBlockADC(ADCBuffer *Arrays){
-	memcpy(Arrays, (void*)ATD0_BASE, 16);
-	memcpy(Arrays+16, (void*)ATD1_BASE, 16);
+	__builtin_memcpy(Arrays, (void*)ATD0_BASE, 16);
+	__builtin_memcpy(Arrays+16, (void*)ATD1_BASE, 16);
 }*/
 
 


### PR DESCRIPTION
Now explicitly require gcc's built-in for memcpy.